### PR TITLE
Add missing dependency on querystring

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "The core `url` packaged standalone for use with Browserify.",
   "version": "0.10.2",
   "dependencies": {
-    "punycode": "1.3.2"
+    "punycode": "1.3.2",
+    "querystring": "0.2.0"
   },
   "main": "./url.js",
   "devDependencies": {


### PR DESCRIPTION
Explicating this dependency helps out downstream with a Browserify-like workflow for dependees of ghub.io/url2.