### PR TITLE
Upgraded to Node v0.12.7

### DIFF
--- a/util.js
+++ b/util.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  isString: function(arg) {
+    return typeof(arg) === 'string';
+  },
+  isObject: function(arg) {
+    return typeof(arg) === 'object' && arg !== null;
+  },
+  isNull: function(arg) {
+    return arg === null;
+  },
+  isNullOrUndefined: function(arg) {
+    return arg == null;
+  }
+};


### PR DESCRIPTION
1. Upgraded `url.js` to Node v0.12.7, which has _many_ new bug fixes.   This code was copied directly from [`joyent/node/lib/url.js`](https://github.com/joyent/node/blob/master/lib/url.js).  The new code has a dependency on the [`util`](https://www.npmjs.com/package/util) module, so I added it to `package.json`.

2. Upgraded `test.js` with _many_ new tests (541 total).  These were copied directly from [`joyent/node/test/simple/test-url.js`](https://github.com/joyent/node/blob/master/test/simple/test-url.js) and wrapped in `test()` statements to work with Mocha and Zuul.  I verified that all tests are passing in Node and web browsers.