### PR TITLE
Run on newer Node.js versions at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
+sudo: false
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "4"
 env:
   global:
   - secure: OgPRLCzHFh5WbjHEKlghHFW1oOreSF2JVUr3CMaFDi03ngTS2WONSw8mRn8SA6FTldiGGBx1n8orDzUw6cdkB7+tkU3G5B0M0V3vl823NaUFKgxsCM3UGDYfJb3yfAG5cj72rVZoX/ABd1fVuG4vBIlDLxsSlKQFMzUCFoyttr8=


### PR DESCRIPTION
* Set sudo:false so that the new faster container system may be used by Travis.
  https://docs.travis-ci.com/user/migrating-from-legacy/
  Right now the last build has a warning about use of legacy infrastructure.

* Include Node.js v0.12 and v4.x stable.