### PR TITLE
Update punycode to 1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6"
 script: "npm run zuul"
 env:
   global:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.11.0",
   "author": "defunctzombie",
   "dependencies": {
-    "punycode": "1.3.2",
+    "punycode": "^1.4.1",
     "querystring": "0.2.0"
   },
   "main": "./url.js",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint": "^7.18.0",
     "mocha": "^3.5.3",
     "nyc": "^10.3.2",
-    "zuul": "3.3.0"
+    "zuul": "^3.3.0"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
The latest 1.x version of punycode is 1.4.1, it's been out for about a year.

All tests appear to run.