### PR TITLE
update version of punycode to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The core `url` packaged standalone for use with Browserify.",
   "version": "0.11.0",
   "dependencies": {
-    "punycode": "1.3.2",
+    "punycode": "2.1.0",
     "querystring": "0.2.0"
   },
   "main": "./url.js",


### PR DESCRIPTION
Fixes issue with punycode when `window.define` and `module.exports` are both defined.