### PR TITLE
feat: replace depracated query-string with URLSearchParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "version": "0.11.0",
   "author": "defunctzombie",
   "dependencies": {
-    "punycode": "^1.4.1",
-    "querystring": "0.2.0"
+    "punycode": "^1.4.1"
   },
   "main": "./url.js",
   "keywords": [

--- a/url.js
+++ b/url.js
@@ -105,8 +105,7 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     'ftp:': true,
     'gopher:': true,
     'file:': true
-  },
-  querystring = require('querystring');
+  };
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
   if (url && util.isObject(url) && url instanceof Url) { return url; }
@@ -151,7 +150,7 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = querystring.parse(this.search.substr(1));
+          this.query = Object.fromEntries(new URLSearchParams(this.search.substr(1)));
         } else {
           this.query = this.search.substr(1);
         }
@@ -373,7 +372,7 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
     this.search = rest.substr(qm);
     this.query = rest.substr(qm + 1);
     if (parseQueryString) {
-      this.query = querystring.parse(this.query);
+      this.query = Object.fromEntries(new URLSearchParams(this.query));
     }
     rest = rest.slice(0, qm);
   } else if (parseQueryString) {
@@ -435,7 +434,7 @@ Url.prototype.format = function () {
   }
 
   if (this.query && util.isObject(this.query) && Object.keys(this.query).length) {
-    query = querystring.stringify(this.query);
+    query = new URLSearchParams(this.query);
   }
 
   var search = this.search || (query && ('?' + query)) || '';


### PR DESCRIPTION
querystring is deprecated for the native URLSearchParams API 
![2021-09-05_13-09](https://user-images.githubusercontent.com/65319051/132133623-73ef7dcf-4547-4d6c-9498-a3d70cc7ecbc.png)
all tests keep passing :D