### PR TITLE
feat: replace the querystring package with the new URLSearchParams api

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "version": "0.11.0",
   "author": "defunctzombie",
   "dependencies": {
-    "punycode": "^1.4.1",
-    "querystring": "0.2.0"
+    "punycode": "^1.4.1"
   },
   "main": "./url.js",
   "keywords": [

--- a/url.js
+++ b/url.js
@@ -104,8 +104,7 @@ var protocolPattern = /^([a-z0-9.+-]+:)/i,
     'ftp:': true,
     'gopher:': true,
     'file:': true
-  },
-  querystring = require('querystring');
+  };
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
   if (url && typeof url === 'object' && url instanceof Url) { return url; }
@@ -150,7 +149,7 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
       if (simplePath[2]) {
         this.search = simplePath[2];
         if (parseQueryString) {
-          this.query = querystring.parse(this.search.substr(1));
+          this.query = Object.fromEntries(new URLSearchParams(this.search.substr(1)));
         } else {
           this.query = this.search.substr(1);
         }
@@ -372,7 +371,7 @@ Url.prototype.parse = function (url, parseQueryString, slashesDenoteHost) {
     this.search = rest.substr(qm);
     this.query = rest.substr(qm + 1);
     if (parseQueryString) {
-      this.query = querystring.parse(this.query);
+      this.query = Object.fromEntries(new URLSearchParams(this.query));
     }
     rest = rest.slice(0, qm);
   } else if (parseQueryString) {
@@ -434,7 +433,7 @@ Url.prototype.format = function () {
   }
 
   if (this.query && typeof this.query === 'object' && Object.keys(this.query).length) {
-    query = querystring.stringify(this.query);
+    query = new URLSearchParams(this.query).toString();
   }
 
   var search = this.search || (query && ('?' + query)) || '';


### PR DESCRIPTION
During an npm install i got this message:
```
npm WARN deprecated querystring@0.2.0: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
```

I tried to replace it in this new API, and all tests in node still succeed, **but I'm unsure if the supported browsers match with what this package supports.**

https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams

On MDN the support for URLSearchParams seems to be quite good:
![image](https://user-images.githubusercontent.com/1710840/146835910-58b31197-a729-470c-a62e-9087ed93a077.png)

https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams#browser_compatibility

This should reduce the package size by about 16%
* https://bundlephobia.com/package/url@0.11.0
* https://bundlephobia.com/package/querystring@0.2.1